### PR TITLE
Added support for transformed sprites

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,7 @@
 -------------------------------------------------------------
+//COCOS2D ZJoystick API (Version1.5) by Thomas Christensen
+1.) Made the automatic restrained area of the controlled sprite calculated on the basis of the sprite's bounding rectangle instead of it's content size. Bounding rect is the size after applying scaling etc. so if sprite gfx is scaled between iPad and iPhone, this will still work.
+-------------------------------------------------------------
 //COCOS2D ZJoystick API (Version1.4) by Christopher Valles
 1.) Added "axisConstrain" variable; this is used to setup a constrain on a specific axis and the joystick will only be able to move on the constrained axis.
 Available constrains are:

--- a/README
+++ b/README
@@ -1,5 +1,5 @@
 -------------------------------------------------------------
-//COCOS2D ZJoystick API (Version1.4)
+//COCOS2D ZJoystick API (Version1.4) by Christopher Valles
 1.) Added "axisConstrain" variable; this is used to setup a constrain on a specific axis and the joystick will only be able to move on the constrained axis.
 Available constrains are:
 

--- a/README
+++ b/README
@@ -1,4 +1,12 @@
 -------------------------------------------------------------
+//COCOS2D ZJoystick API (Version1.4)
+1.) Added "axisConstrain" variable; this is used to setup a constrain on a specific axis and the joystick will only be able to move on the constrained axis.
+Available constrains are:
+
+kXAxisConstrain: Only will move on the X axis
+kYAxisConstrain: Only will move on the Y axis
+kNoContrain: Will be able to move on both axis
+-------------------------------------------------------------
 //COCOS2D ZJoystick API (Version1.3)
 [Version 1.3 Updates]
 1.) Added new protocol method:

--- a/ZJoystick.h
+++ b/ZJoystick.h
@@ -27,7 +27,7 @@
 #import "cocos2d.h"
 
 typedef enum {
-	kJLowerLeft,
+	kLowerLeft,
 	kLowerRight,
 }tJoystickPlacement;
 
@@ -38,12 +38,19 @@ typedef enum {
 	kFourthQuadrant,
 }tControlQuadrant;
 
+//version 1.4
+typedef enum{
+    kXAxisConstrain,
+    kYAxisConstrain,
+    kNoConstrain
+}tAxisConstrain;
+
 @protocol ZJoystickDelegate<NSObject>
 
 @optional
--(void)joystickControlBegan;
--(void)joystickControlMoved;
--(void)joystickControlEnded;
+-(void)joystickControlBegan:(id)joystick;
+-(void)joystickControlMoved:(id)joystick;
+-(void)joystickControlEnded:(id)joystick;
 //version 1.3
 -(void)joystickControlDidUpdate:(id)joystick toXSpeedRatio:(CGFloat)xSpeedRatio toYSpeedRatio:(CGFloat)ySpeedRatio;
 @end
@@ -70,6 +77,8 @@ typedef enum {
     //version 1.2
     CGFloat                 _joystickRadius;
     int                     _joystickTag;
+    //version 1.4
+    tAxisConstrain          _axisConstrain;
 }
 
 @property(nonatomic, retain) CCTexture2D				*normalTexture;
@@ -90,6 +99,9 @@ typedef enum {
 //version 1.2
 @property(nonatomic, assign) CGFloat                    joystickRadius;
 @property(nonatomic, assign) int                        joystickTag;
+
+//version 1.4
+@property(nonatomic, assign) tAxisConstrain             axisConstrain;
 
 -(CGRect) getBoundingRect;
 -(CGFloat)getYMinimumLimit;

--- a/ZJoystick.m
+++ b/ZJoystick.m
@@ -50,6 +50,8 @@ CGFloat getDistanceBetweenTwoPoints(CGPoint point1,CGPoint point2);
 @synthesize joystickRadius          = _joystickRadius;
 //version 1.3
 @synthesize joystickTag             = _joystickTag;
+//version 1.4
+@synthesize axisConstrain           = _axisConstrain;
 
 //m = y2-y1 / x2-x1
 CGFloat getSlope(CGPoint point1, CGPoint point2) {
@@ -238,6 +240,8 @@ tControlQuadrant getQuadrantForPoint (CGPoint point) {
 	joystick.controllerSpriteFile = controllerSprite;
     joystick.speedRatio     = 1.0;                  //added default values which is 1
     joystick.joystickRadius = kJoystickRadius;      //added default values for joystick radius which is 50
+    
+    joystick.axisConstrain = kNoConstrain;
 	return joystick;
 }
 
@@ -272,8 +276,8 @@ tControlQuadrant getQuadrantForPoint (CGPoint point) {
         //call delegate method
         //check if _delegate conforms to the protocol and responds to the selector
         if ([_delegate conformsToProtocol:@protocol(ZJoystickDelegate)]) {
-            if([_delegate respondsToSelector:@selector(joystickControlBegan)]) {
-                [_delegate performSelector:@selector(joystickControlBegan)];
+            if([_delegate respondsToSelector:@selector(joystickControlBegan:)]) {
+                [_delegate joystickControlBegan:self];
             }
         }
         
@@ -298,7 +302,14 @@ tControlQuadrant getQuadrantForPoint (CGPoint point) {
 		[self setTexture:_normalTexture];
 		
 		//jostick button controller
-		_controller.position = ccp(self.contentSize.width/2 + actualPoint.x, self.contentSize.height/2 + actualPoint.y);
+        //version 1.4
+        if(self.axisConstrain == kNoConstrain){
+            _controller.position = ccp(self.contentSize.width/2 + actualPoint.x, self.contentSize.height/2 + actualPoint.y);
+        }else if(self.axisConstrain == kXAxisConstrain){
+            _controller.position = ccp(self.contentSize.width/2 + actualPoint.x, self.contentSize.height/2);
+        }else if(self.axisConstrain == kYAxisConstrain){
+            _controller.position = ccp(self.contentSize.width/2, self.contentSize.height/2 + actualPoint.y);
+        }
         
 		//add fadeIn animation
 		id inAction = [CCFadeIn actionWithDuration:kControlActionInterval];
@@ -322,7 +333,6 @@ tControlQuadrant getQuadrantForPoint (CGPoint point) {
 }
 
 - (void)ccTouchMoved:(UITouch *)touch withEvent:(UIEvent *)event{
-	CCLOG(@"Joystick ccTouchMoved");
 	CGPoint location	= [touch locationInView: [touch view]];
 	location			= [[CCDirector sharedDirector] convertToGL:location];
 	//CGRect rect			= [self getBoundingRect];
@@ -337,8 +347,8 @@ tControlQuadrant getQuadrantForPoint (CGPoint point) {
         //execute our delegate method
         //check if _delegate conforms to the protocol and responds to the selector
         if ([_delegate conformsToProtocol:@protocol(ZJoystickDelegate)]) {
-            if([_delegate respondsToSelector:@selector(joystickControlMoved)]) {
-                [_delegate performSelector:@selector(joystickControlMoved)];
+            if([_delegate respondsToSelector:@selector(joystickControlMoved:)]) {
+                [_delegate joystickControlMoved:self];
             }
         }
         
@@ -360,7 +370,15 @@ tControlQuadrant getQuadrantForPoint (CGPoint point) {
 			self.controllerActualPoint = actualPoint;
 			
 			//jostick button controller
-			_controller.position = ccp(self.contentSize.width/2 + actualPoint.x, self.contentSize.height/2 + actualPoint.y);
+            //version 1.4
+            if(self.axisConstrain == kNoConstrain){
+                _controller.position = ccp(self.contentSize.width/2 + actualPoint.x, self.contentSize.height/2 + actualPoint.y);
+            }else if(self.axisConstrain == kXAxisConstrain){
+                _controller.position = ccp(self.contentSize.width/2 + actualPoint.x, self.contentSize.height/2);
+            }else if(self.axisConstrain == kYAxisConstrain){
+                _controller.position = ccp(self.contentSize.width/2, self.contentSize.height/2 + actualPoint.y);
+            }
+            
 			//call delegate method
 			
 		} else {
@@ -403,7 +421,15 @@ tControlQuadrant getQuadrantForPoint (CGPoint point) {
 			}
 			
 			//we add the position of joystick since we need to position the controller surrounding the joystick
-			CGPoint controllerPoint = CGPointMake(point.x + self.contentSize.width/2, point.y + self.contentSize.height/2);
+            //version 1.4
+            CGPoint controllerPoint;
+            if(self.axisConstrain == kNoConstrain){
+                controllerPoint = CGPointMake(point.x + self.contentSize.width/2, point.y + self.contentSize.height/2);
+            }else if(self.axisConstrain == kXAxisConstrain){
+                controllerPoint = CGPointMake(point.x + self.contentSize.width/2, self.contentSize.height/2);
+            }else if(self.axisConstrain == kYAxisConstrain){
+                controllerPoint = CGPointMake(self.contentSize.width/2, point.y + self.contentSize.height/2);
+            }
 			
 			//CCLOG(@"POINT VALUE = (%f, %f)", point.x, point.y);
 			//CCLOG(@"SQUAREROOT of 1 = %f",sqrt(1.0f));		
@@ -439,8 +465,8 @@ tControlQuadrant getQuadrantForPoint (CGPoint point) {
     //execute our delegate method
     //check if _delegate conforms to the protocol and responds to the selector
     if ([_delegate conformsToProtocol:@protocol(ZJoystickDelegate)]) {
-        if([_delegate respondsToSelector:@selector(joystickControlEnded)]) {
-            [_delegate performSelector:@selector(joystickControlEnded)];
+        if([_delegate respondsToSelector:@selector(joystickControlEnded:)]) {
+            [_delegate joystickControlEnded:self];
         }
     }
     

--- a/ZJoystick.m
+++ b/ZJoystick.m
@@ -154,7 +154,8 @@ tControlQuadrant getQuadrantForPoint (CGPoint point) {
 -(CGSize)getControlledObjectSize {
     //version 1.3
 	CCSprite *controlledObject = (CCSprite *)_controlledObject;
-    CGSize  cSize = controlledObject.contentSize;
+    //version 1.5
+    CGSize cSize = [controlledObject boundingBox].size;
     
     return cSize;
 }


### PR DESCRIPTION
Made the automatic restrained area of the controlled sprite calculated on the basis of the sprite's bounding rectangle instead of it's content size. Bounding rect is the size after applying scaling etc. so if sprite gfx is scaled between iPad and iPhone, this will still work.
